### PR TITLE
fix: update TemplateResponse calls to new Starlette signature

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ pptx_processor = PPTXProcessor()
 
 @app.get("/", response_class=HTMLResponse)
 async def index(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+    return templates.TemplateResponse(request, "index.html")
 
 
 @app.post("/remove_watermark")
@@ -45,20 +45,16 @@ async def remove_watermark(request: Request, pdf_file: UploadFile = File(...)):
     """
     if not pdf_file.filename:
         return templates.TemplateResponse(
+            request,
             "index.html",
-            {
-                "request": request,
-                "error_message": "No file selected. Please choose a PDF or PPTX file.",
-            },
+            {"error_message": "No file selected. Please choose a PDF or PPTX file."},
         )
 
     if not allowed_file(pdf_file.filename):
         return templates.TemplateResponse(
+            request,
             "index.html",
-            {
-                "request": request,
-                "error_message": "Invalid file type. Please upload a PDF or PowerPoint (.pptx) file.",
-            },
+            {"error_message": "Invalid file type. Please upload a PDF or PowerPoint (.pptx) file."},
         )
 
     # Extract extension before secure_filename to handle Unicode filenames
@@ -67,9 +63,7 @@ async def remove_watermark(request: Request, pdf_file: UploadFile = File(...)):
 
     # If secure_filename stripped the extension (e.g., Cyrillic names), restore it
     if not get_file_extension(filename) and original_extension:
-        # Generate a safe filename with preserved extension
         import uuid
-
         filename = f"{uuid.uuid4().hex[:8]}.{original_extension}"
 
     file_extension = get_file_extension(filename)
@@ -81,11 +75,9 @@ async def remove_watermark(request: Request, pdf_file: UploadFile = File(...)):
     # Additional validation: ensure we have a valid extension
     if not file_extension:
         return templates.TemplateResponse(
+            request,
             "index.html",
-            {
-                "request": request,
-                "error_message": "Invalid file name. Please upload a file with a proper extension (.pdf or .pptx).",
-            },
+            {"error_message": "Invalid file name. Please upload a file with a proper extension (.pdf or .pptx)."},
         )
 
     # Create temp file with appropriate extension
@@ -106,21 +98,17 @@ async def remove_watermark(request: Request, pdf_file: UploadFile = File(...)):
                 return await _process_pptx(request, upload_path, filename)
             else:
                 return templates.TemplateResponse(
+                    request,
                     "index.html",
-                    {
-                        "request": request,
-                        "error_message": f"Unsupported file type: {file_extension}",
-                    },
+                    {"error_message": f"Unsupported file type: {file_extension}"},
                 )
 
         except Exception as e:
             logger.error(f"Error processing file: {str(e)}")
             return templates.TemplateResponse(
+                request,
                 "index.html",
-                {
-                    "request": request,
-                    "error_message": f"Error processing file: {str(e)}",
-                },
+                {"error_message": f"Error processing file: {str(e)}"},
             )
 
         finally:
@@ -140,13 +128,13 @@ async def _process_pdf(request: Request, upload_path: str, filename: str):
     if not result["success"]:
         raise Exception(result["error"])
 
-    template_data = {"request": request, "success_message": result["message"]}
+    context = {"success_message": result["message"]}
 
     if result["has_watermark"]:
-        template_data["download_filename"] = output_filename
-        template_data["file_type"] = "pdf"
+        context["download_filename"] = output_filename
+        context["file_type"] = "pdf"
 
-    return templates.TemplateResponse("index.html", template_data)
+    return templates.TemplateResponse(request, "index.html", context)
 
 
 async def _process_pptx(request: Request, upload_path: str, filename: str):
@@ -159,13 +147,13 @@ async def _process_pptx(request: Request, upload_path: str, filename: str):
     if not result["success"]:
         raise Exception(result["error"])
 
-    template_data = {"request": request, "success_message": result["message"]}
+    context = {"success_message": result["message"]}
 
     if result["has_watermark"]:
-        template_data["download_filename"] = output_filename
-        template_data["file_type"] = "pptx"
+        context["download_filename"] = output_filename
+        context["file_type"] = "pptx"
 
-    return templates.TemplateResponse("index.html", template_data)
+    return templates.TemplateResponse(request, "index.html", context)
 
 
 # ===========================
@@ -174,14 +162,12 @@ async def _process_pptx(request: Request, upload_path: str, filename: str):
 @app.get("/download/{filename}")
 async def download_processed_file(filename: str):
     from fastapi.responses import FileResponse
+    from utils.file_helpers import get_mime_type
 
     file_path = os.path.join(OUTPUT_FOLDER, filename)
 
     if not os.path.exists(file_path):
         return {"error": "File not found."}
-
-    # Determine MIME type based on file extension
-    from utils.file_helpers import get_mime_type
 
     file_extension = get_file_extension(filename)
     mime_type = get_mime_type(file_extension)
@@ -195,13 +181,15 @@ async def download_processed_file(filename: str):
 async def http_exception_handler(request: Request, exc: StarletteHTTPException):
     if exc.status_code == 404:
         return templates.TemplateResponse(
+            request,
             "index.html",
-            {"request": request, "error_message": "Page not found."},
+            {"error_message": "Page not found."},
             status_code=404,
         )
     return templates.TemplateResponse(
+        request,
         "index.html",
-        {"request": request, "error_message": f"Server error: {exc.detail}"},
+        {"error_message": f"Server error: {exc.detail}"},
         status_code=exc.status_code,
     )
 
@@ -209,8 +197,9 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException):
 @app.exception_handler(Exception)
 async def general_exception_handler(request: Request, exc: Exception):
     return templates.TemplateResponse(
+        request,
         "index.html",
-        {"request": request, "error_message": f"Internal server error: {str(exc)}"},
+        {"error_message": f"Internal server error: {str(exc)}"},
         status_code=500,
     )
 


### PR DESCRIPTION
## Problem

Running the app with recent versions of Starlette/FastAPI throws a 500 error on every page load:

```
TypeError: unhashable type: 'dict'
```

This happens because the old `TemplateResponse` signature passed `request` inside the context dict:

```python
# old (broken)
TemplateResponse("index.html", {"request": request, "key": "value"})
```

Starlette updated the signature so `request` is now the first positional argument and should not be in the context dict:

```python
# new (correct)
TemplateResponse(request, "index.html", {"key": "value"})
```

## Fix

Updated all `TemplateResponse` calls in `app.py` to use the new signature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure improvements for better organization and maintainability. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->